### PR TITLE
Pass interactions to rosettafold2na via a dedicated csv file

### DIFF
--- a/assets/schema_interactions.json
+++ b/assets/schema_interactions.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/nf-core/proteinfold/master/assets/schema_interactions.json",
+    "title": "nf-core/proteinfold pipeline - params.interactions schema",
+    "description": "Schema for the file provided with params.interactions",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "protein_id": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Protein sequence name must be provided and cannot contain spaces",
+                "meta": ["protein_id"]
+            },
+            "interaction_id": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Molecule interancting sequence name must be provided and cannot contain spaces",
+                "meta": ["interaction_id"]
+            },
+            "interaction_type": {
+                "type": "string",
+                "pattern": "^(P|D|R|S|PR)$",
+                "errorMessage": "Molecule interancting sequence name must be provided and cannot contain spaces",
+                "meta": ["interaction_type"]
+            }
+        },
+        "required": ["protein_id", "interaction_id", "interaction_type"]    
+    }
+}

--- a/conf/test_rosettafold2na.config
+++ b/conf/test_rosettafold2na.config
@@ -26,11 +26,12 @@ params {
     // Input data to test rosettafold2na
     mode                 = 'rosettafold2na'
     rosettafold2na_db    = "${projectDir}/assets/dummy_db_dir"
-    input                = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v1.0/samplesheet.csv'
+    input                = params.pipelines_testdata_base_path + 'proteinfold/testdata/samplesheet/v1.2/samplesheet.csv'
+    interactions         = params.pipelines_testdata_base_path + 'proteinfold/testdata/interactions/v1.2/interactions.csv'
 }
 
 process {
     withName: 'RUN_ROSETTAFOLD2NA' {
-        container = 'quay.io/patribota/proteinfold_rosettafold2na:dev'
+        container = 'biocontainers/gawk:5.1.0'
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -71,10 +71,12 @@ ch_dummy_file = Channel.fromPath("$projectDir/assets/NO_FILE")
 workflow NFCORE_PROTEINFOLD {
 
     take:
-    samplesheet // channel: samplesheet read in from --input
+    samplesheet  // channel: samplesheet read in from --input
+    interactions // channel: interactions read in from --interactions
 
     main:
     ch_samplesheet                          = samplesheet
+    ch_interactions                         = interactions
     ch_alphafold_top_ranked_pdb             = Channel.empty()
     ch_colabfold_top_ranked_pdb             = Channel.empty()
     ch_esmfold_top_ranked_pdb               = Channel.empty()
@@ -355,6 +357,7 @@ workflow NFCORE_PROTEINFOLD {
         //
         ROSETTAFOLD2NA (
             ch_samplesheet,
+            ch_interactions,
             ch_versions,
             PREPARE_ROSETTAFOLD2NA_DBS.out.uniref30,
             PREPARE_ROSETTAFOLD2NA_DBS.out.bfd,
@@ -440,14 +443,16 @@ workflow {
         params.monochrome_logs,
         args,
         params.outdir,
-        params.input
+        params.input,
+        params.interactions
     )
 
     //
     // WORKFLOW: Run main workflow
     //
     NFCORE_PROTEINFOLD (
-        PIPELINE_INITIALISATION.out.samplesheet
+        PIPELINE_INITIALISATION.out.samplesheet,
+        PIPELINE_INITIALISATION.out.interactions
     )
 
     //

--- a/modules/local/run_rosettafold2na/main.nf
+++ b/modules/local/run_rosettafold2na/main.nf
@@ -5,15 +5,10 @@ process RUN_ROSETTAFOLD2NA {
     tag "$meta.id"
     label 'process_medium'
 
-    // Exit if running this module with -profile conda / -profile mamba
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        error("Local RUN_RF2NA module does not support Conda. Please use Docker / Singularity / Podman instead.")
-    }
-
     container "quay.io/patribota/proteinfold_rosettafold2na:dev"
 
     input:
-    tuple val(meta), path(fasta_files)
+    tuple val(meta), path(protein_fasta), path(interaction_fasta)
     path ('bfd/*')
     path ('UniRef30_2020_06/*')
     path ('pdb100_2021Mar03/*')
@@ -29,20 +24,16 @@ process RUN_ROSETTAFOLD2NA {
     task.ext.when == null || task.ext.when
 
     script:
+    // Exit if running this module with -profile conda / -profile mamba
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        error("Local RUN_RF2NA module does not support Conda. Please use Docker / Singularity / Podman instead.")
+    }
+
     def args = task.ext.args ?: ''
     def VERSION = 'dev' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
-    def fasta_args = fasta_files.collect { fasta ->
-        def prefix = fasta.name.tokenize(':')[0]
-        if (prefix == 'P') return "P:${fasta}"
-        else if (prefix == 'R') return "R:${fasta}"
-        else if (prefix == 'D') return "D:${fasta}"
-        else if (prefix == 'S') return "S:${fasta}"
-        else if (prefix == 'PR') return "PR:${fasta}"
-        else return fasta
-    }.join(' ')
 
     """
-    run_RF2NA.sh ${meta.id}_rf2na_output $fasta_args
+    run_RF2NA.sh ${meta.id}_rf2na_output $protein_fasta ${meta.interaction_type}:${interaction_fasta}
 
     cp ${meta.id}_rf2na_output/models/model_00.pdb ./${meta.id}_rf2na.pdb
 
@@ -58,7 +49,7 @@ process RUN_ROSETTAFOLD2NA {
 
     stub:
     """
-    touch ${meta.id}_rf2na.pdb
+    touch "${meta.id}_rf2na.pdb"
     touch "${meta.id}_plddt_mqc.tsv"
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ params {
 
     // Input options
     input                       = null
+    interactions                = null
     mode                        = 'alphafold2' // {alphafold2, colabfold, esmfold, rosettafold_all_atom, helixfold3, rosettafold2na}
     use_gpu                     = false
     split_fasta                 = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -156,6 +156,17 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
+                "interactions": {
+                    "type": "string",
+                    "format": "file-path",
+                    "exists": true,
+                    "schema": "assets/schema_interactions.json",
+                    "mimetype": "text/csv",
+                    "pattern": "^\\S+\\.csv$",
+                    "description": "Path to comma-separated file containing information about the samples interactions for rosettafold2dna mode.",
+                    "help_text": "You will need to create a design file with information about the interactions of your samples samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row. See [usage docs](https://nf-co.re/proteinfold/usage#samplesheet-input).",
+                    "fa_icon": "fas fa-file-csv"
+                },
                 "mode": {
                     "type": "string",
                     "default": "alphafold2",

--- a/subworkflows/local/utils_nfcore_proteinfold_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinfold_pipeline/main.nf
@@ -32,6 +32,7 @@ workflow PIPELINE_INITIALISATION {
     nextflow_cli_args //   array: List of positional nextflow CLI args
     outdir            //  string: The output directory where the results will be saved
     input             //  string: Path to input samplesheet
+    interactions      //  string: Path to input interactions
 
     main:
     ch_versions = Channel.empty()
@@ -63,9 +64,43 @@ workflow PIPELINE_INITIALISATION {
     )
 
     //
-    // Create channel from input file provided through params.input
+    // Create channel from input file provided through params.input and params.interactions
     //
     ch_samplesheet = Channel.fromList(samplesheetToList(params.input, "assets/schema_input.json"))
+    // // TODO: Implement if params.interactions is provided
+    ch_interactions = Channel.fromList(samplesheetToList(params.interactions, "assets/schema_interactions.json"))
+
+    sample_ids = ch_samplesheet
+                    .map { meta, file -> 
+                        meta.id 
+                    }
+                    .collect()
+                    .toList()
+
+    ch_interactions
+        .combine(sample_ids)
+        .branch {
+            meta, sample_ids ->
+                // println "Debug: protein_id=${meta.protein_id}, interaction_id=${meta.interaction_id}, interaction_type=${meta.interaction_type}, sample_ids=${sample_ids}"
+                // "Debug: protein_id=
+                valid: sample_ids.contains(meta.protein_id) && sample_ids.contains(meta.interaction_id) ? meta.protein_id : null
+                invalid: !(sample_ids.contains(meta.protein_id) && sample_ids.contains(meta.interaction_id)) ? meta.protein_id : null
+        }
+        .set { ch_interactions_validated }
+
+    ch_interactions_validated.invalid
+        .subscribe { meta, samples_ids ->
+            log.info "WARNING: Row \"${meta.protein_id},${meta.interaction_id},${meta.interaction_type}\", in interactions is not valid (check the IDs correspond to those in samplesheet)."
+        }
+    
+    ch_interactions_validated.valid
+        .ifEmpty { log.error "No valid interactions found in the interactions file. Please check the IDs correspond to those in samplesheet." }
+        .map {
+            meta, samples_ids ->
+                meta   
+        }
+        .set { interactions }
+
     if (params.split_fasta) {
         // TODO: here we have to validate that the ids are unique and valid as an extra step
         // since it is not done with the samplesheet schema (they are all in the same file)
@@ -87,8 +122,9 @@ workflow PIPELINE_INITIALISATION {
     }
 
     emit:
-    samplesheet = ch_samplesheet
-    versions    = ch_versions
+    samplesheet  = ch_samplesheet
+    interactions = interactions
+    versions     = ch_versions
 }
 
 /*

--- a/subworkflows/local/utils_nfcore_proteinfold_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_proteinfold_pipeline/main.nf
@@ -67,39 +67,46 @@ workflow PIPELINE_INITIALISATION {
     // Create channel from input file provided through params.input and params.interactions
     //
     ch_samplesheet = Channel.fromList(samplesheetToList(params.input, "assets/schema_input.json"))
-    // // TODO: Implement if params.interactions is provided
-    ch_interactions = Channel.fromList(samplesheetToList(params.interactions, "assets/schema_interactions.json"))
 
-    sample_ids = ch_samplesheet
-                    .map { meta, file -> 
-                        meta.id 
-                    }
-                    .collect()
-                    .toList()
+    if (params.interactions) {
+        if (!params.mode.toLowerCase().split(",").contains("rosettafold2na")) {
+            log.info "WARNING: The --interactions parameter is only supported in the ROSETTAFOLD2NA mode."
+        }
+        
+        //
+        // Create channel from input file provided through params.interactions
+        //
+        ch_interactions = Channel.fromList(samplesheetToList(params.interactions, "assets/schema_interactions.json"))
 
-    ch_interactions
-        .combine(sample_ids)
-        .branch {
-            meta, sample_ids ->
-                // println "Debug: protein_id=${meta.protein_id}, interaction_id=${meta.interaction_id}, interaction_type=${meta.interaction_type}, sample_ids=${sample_ids}"
-                // "Debug: protein_id=
-                valid: sample_ids.contains(meta.protein_id) && sample_ids.contains(meta.interaction_id) ? meta.protein_id : null
-                invalid: !(sample_ids.contains(meta.protein_id) && sample_ids.contains(meta.interaction_id)) ? meta.protein_id : null
-        }
-        .set { ch_interactions_validated }
+        sample_ids = ch_samplesheet
+                        .map { meta, file -> 
+                            meta.id 
+                        }
+                        .collect()
+                        .toList()
 
-    ch_interactions_validated.invalid
-        .subscribe { meta, samples_ids ->
-            log.info "WARNING: Row \"${meta.protein_id},${meta.interaction_id},${meta.interaction_type}\", in interactions is not valid (check the IDs correspond to those in samplesheet)."
-        }
-    
-    ch_interactions_validated.valid
-        .ifEmpty { log.error "No valid interactions found in the interactions file. Please check the IDs correspond to those in samplesheet." }
-        .map {
-            meta, samples_ids ->
-                meta   
-        }
-        .set { interactions }
+        ch_interactions
+            .combine(sample_ids)
+            .branch {
+                meta, ids ->
+                    valid: ids.contains(meta.protein_id) && ids.contains(meta.interaction_id) ? meta.protein_id : null
+                    invalid: !(ids.contains(meta.protein_id) && ids.contains(meta.interaction_id)) ? meta.protein_id : null
+            }
+            .set { ch_interactions_validated }
+
+        ch_interactions_validated.invalid
+            .subscribe { meta, samples_ids ->
+                log.info "WARNING: Row \"${meta.protein_id},${meta.interaction_id},${meta.interaction_type}\", in interactions is not valid (check the IDs correspond to those in samplesheet)."
+            }
+        
+        ch_interactions_validated.valid
+            .ifEmpty { log.error "No valid interactions found in the interactions file. Please check the IDs correspond to those in samplesheet." }
+            .map {
+                meta, samples_ids ->
+                    meta   
+            }
+            .set { interactions }
+    }
 
     if (params.split_fasta) {
         // TODO: here we have to validate that the ids are unique and valid as an extra step

--- a/workflows/rosettafold2na.nf
+++ b/workflows/rosettafold2na.nf
@@ -19,6 +19,7 @@ workflow ROSETTAFOLD2NA {
 
     take:
     ch_samplesheet          // channel: samplesheet read in from --input
+    ch_interactions         // channel: interactions read in from --interactions
     ch_versions             // channel: [ path(versions.yml) ]
     ch_bfd                  // channel: path(bfd)
     ch_uniref30             // channel: path(uniref30)
@@ -33,8 +34,24 @@ workflow ROSETTAFOLD2NA {
     ch_pdb_msa        = Channel.empty()
     ch_multiqc_report = Channel.empty()
 
+    ch_samplesheet_reshaped = ch_samplesheet.map { 
+        meta, file -> [ meta.id, file ] }
+ 
+    ch_protein_interaction = ch_interactions
+                                .map { 
+                                    [ it.protein_id, it.interaction_id, it.interaction_type ]     
+                                }
+                                .join(ch_samplesheet_reshaped, by: 0)
+                                .map {
+                                    [ it[1], it[0], it[2], it[3] ] // [ protein_id, interaction_id, interaction_type, file ]
+                                }
+                                .join(ch_samplesheet_reshaped, by: 0)
+                                .map {
+                                    [ [ id: it[1], interaction_id: it[0], interaction_type: it[2] ], it[3], it[4] ] // [ protein_id, interaction_id, interaction_type, file ]
+                                }
+
     RUN_ROSETTAFOLD2NA (
-        ch_samplesheet,
+        ch_protein_interaction,
         ch_bfd,
         ch_uniref30,
         ch_pdb100,


### PR DESCRIPTION
Changing how interactions for `rosettafold2na` are passed to the process and implementing all the logic around:
- schema for the interactions file
- validation for sequence to be present in samplesheet
- test config update
